### PR TITLE
Add missing library as dependency (model_test)

### DIFF
--- a/tfwss/setup/requirements_ubu.txt
+++ b/tfwss/setup/requirements_ubu.txt
@@ -29,6 +29,7 @@ harfbuzz=1.3.4=2
 hdf5=1.10.1=1
 html5lib=0.9999999=py36_0
 icu=58.2=0
+imageio=2.2.0
 ipykernel=4.6.1=py36_0
 ipython=6.1.0=py36_0
 ipython_genutils=0.2.0=py36_0

--- a/tfwss/setup/requirements_win.txt
+++ b/tfwss/setup/requirements_win.txt
@@ -13,6 +13,7 @@ ffmpeg=3.4.1=0
 freetype=2.7=vc14_1
 html5lib=0.999=py36_0
 icu=58.2=vc14_0
+imageio=2.2.0
 ipykernel=4.6.1=py36_0
 ipython=6.1.0=py36_0
 ipython_genutils=0.2.0=py36_0


### PR DESCRIPTION
This is a PR adding the missing library `imageio` for the notebook `model_test.pynb`.

Best,
Dani 